### PR TITLE
Mirror of netflix hollow#213

### DIFF
--- a/hollow/src/main/java/com/netflix/hollow/api/producer/AbstractHollowMultiPublisher.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/producer/AbstractHollowMultiPublisher.java
@@ -1,0 +1,35 @@
+/*
+ *
+ *  Copyright 2018 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.hollow.api.producer;
+
+import java.util.List;
+
+/**
+ * Warning: This is a BETA API and is subject to breaking changes.
+ *
+ * Allows a producer to publish to multiple cloud/regions in the same cycle
+ */
+public abstract class AbstractHollowMultiPublisher implements HollowProducer.Publisher {
+    protected final List<HollowProducer.Publisher> publishers;
+
+    protected AbstractHollowMultiPublisher(List<HollowProducer.Publisher> publishers) {
+        this.publishers = publishers;
+    }
+
+    public abstract void publish(HollowProducer.Blob blob);
+}

--- a/hollow/src/main/java/com/netflix/hollow/api/producer/ParallelHollowMultiPublisher.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/producer/ParallelHollowMultiPublisher.java
@@ -1,0 +1,59 @@
+/*
+ *
+ *  Copyright 2018 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.hollow.api.producer;
+
+import com.netflix.hollow.core.util.SimultaneousExecutor;
+
+import java.util.List;
+import java.util.logging.Logger;
+
+/**
+ * Warning: This is a BETA API and is subject to breaking changes.
+ *
+ * Allows a producer to publish to multiple cloud/regions at the same time
+ */
+public class ParallelHollowMultiPublisher extends AbstractHollowMultiPublisher {
+
+    private static final Logger LOG = Logger.getLogger(ParallelHollowMultiPublisher.class.getName());
+
+    private final double threadsPerCpu;
+
+    public ParallelHollowMultiPublisher(List<HollowProducer.Publisher> publishers, double threadsPerCpu) {
+        super(publishers);
+        this.threadsPerCpu = threadsPerCpu;
+    }
+
+    @Override
+    public void publish(final HollowProducer.Blob blob) {
+        SimultaneousExecutor executor = new SimultaneousExecutor(threadsPerCpu);
+        for(final HollowProducer.Publisher publisher : publishers) {
+            executor.execute(new Runnable() {
+                public void run() {
+                    publisher.publish(blob);
+                }
+            });
+        }
+
+        try {
+            executor.awaitSuccessfulCompletion();
+        } catch(Throwable t) {
+            LOG.warning("Could not publish blob" + t);
+            throw new RuntimeException(t);
+        }
+    }
+}

--- a/hollow/src/main/java/com/netflix/hollow/api/producer/SingleHollowMultiPublisher.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/producer/SingleHollowMultiPublisher.java
@@ -1,0 +1,47 @@
+/*
+ *
+ *  Copyright 2018 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.hollow.api.producer;
+
+import java.util.List;
+import java.util.logging.Logger;
+
+/**
+ * Warning: This is a BETA API and is subject to breaking changes.
+ *
+ * Allows a producer to publish to multiple cloud/regions at the same time
+ */
+public class SingleHollowMultiPublisher extends AbstractHollowMultiPublisher {
+
+    private static final Logger LOG = Logger.getLogger(SingleHollowMultiPublisher.class.getName());
+
+    public SingleHollowMultiPublisher(List<HollowProducer.Publisher> publishers) {
+        super(publishers);
+    }
+
+    @Override
+    public void publish(final HollowProducer.Blob blob) {
+        try {
+            for(final HollowProducer.Publisher publisher : publishers) {
+                publisher.publish(blob);
+            }
+        } catch(Throwable t) {
+            LOG.warning("Could not publish blob" + t);
+            throw new RuntimeException(t);
+        }
+    }
+}

--- a/hollow/src/test/java/com/netflix/hollow/api/producer/HollowMultiPublisherTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/api/producer/HollowMultiPublisherTest.java
@@ -25,12 +25,11 @@ import com.netflix.hollow.api.producer.HollowProducer.WriteState;
 import com.netflix.hollow.api.producer.fs.HollowInMemoryBlobStager;
 import com.netflix.hollow.core.index.HollowPrimaryKeyIndex;
 import com.netflix.hollow.core.write.objectmapper.HollowPrimaryKey;
+import java.util.ArrayList;
+import java.util.List;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-
-import java.util.ArrayList;
-import java.util.List;
 
 public class HollowMultiPublisherTest {
 

--- a/hollow/src/test/java/com/netflix/hollow/api/producer/HollowMultiPublisherTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/api/producer/HollowMultiPublisherTest.java
@@ -1,6 +1,6 @@
 /*
  *
- *  Copyright 2017 Netflix, Inc.
+ *  Copyright 2018 Netflix, Inc.
  *
  *     Licensed under the Apache License, Version 2.0 (the "License");
  *     you may not use this file except in compliance with the License.

--- a/hollow/src/test/java/com/netflix/hollow/api/producer/HollowMultiPublisherTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/api/producer/HollowMultiPublisherTest.java
@@ -1,0 +1,153 @@
+/*
+ *
+ *  Copyright 2017 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.hollow.api.producer;
+
+import com.netflix.hollow.api.consumer.HollowConsumer;
+import com.netflix.hollow.api.consumer.InMemoryBlobStore;
+import com.netflix.hollow.api.objects.generic.GenericHollowObject;
+import com.netflix.hollow.api.producer.HollowProducer.Populator;
+import com.netflix.hollow.api.producer.HollowProducer.WriteState;
+import com.netflix.hollow.api.producer.fs.HollowInMemoryBlobStager;
+import com.netflix.hollow.core.index.HollowPrimaryKeyIndex;
+import com.netflix.hollow.core.write.objectmapper.HollowPrimaryKey;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class HollowMultiPublisherTest {
+
+    private InMemoryBlobStore blobStorage1;
+    private InMemoryBlobStore blobStorage2;
+
+    @Before
+    public void setUp() {
+        blobStorage1 = new InMemoryBlobStore();
+        blobStorage2 = new InMemoryBlobStore();
+    }
+
+
+    @Test
+    public void publishToMultipleStoragesInParallel() {
+        List<HollowProducer.Publisher> publishers = new ArrayList<>();
+        publishers.add(blobStorage1);
+        publishers.add(blobStorage2);
+
+        ParallelHollowMultiPublisher parallelHollowMultiPublisher = new ParallelHollowMultiPublisher(publishers, 2.0d);
+
+        HollowProducer producer = createInMemoryProducer(parallelHollowMultiPublisher);
+
+        /// initialize the data -- classic producer creates the first state in the delta chain.
+        long version = initializeData(producer);
+
+        /// now we read the changes on each storage
+        verifyStorages(blobStorage1, blobStorage2, version);
+    }
+
+    @Test
+    public void publishToMultipleStorages() {
+        List<HollowProducer.Publisher> publishers = new ArrayList<>();
+        publishers.add(blobStorage1);
+        publishers.add(blobStorage2);
+
+        SingleHollowMultiPublisher parallelHollowMultiPublisher = new SingleHollowMultiPublisher(publishers);
+
+        HollowProducer producer = createInMemoryProducer(parallelHollowMultiPublisher);
+
+        /// initialize the data -- classic producer creates the first state in the delta chain.
+        long version = initializeData(producer);
+
+        /// now we read the changes on each storage
+        verifyStorages(blobStorage1, blobStorage2, version);
+    }
+
+    private void verifyStorages(InMemoryBlobStore blobStorage1, InMemoryBlobStore blobStorage2, long version) {
+        HollowConsumer consumerBlobStorage1 = HollowConsumer.withBlobRetriever(blobStorage1).build();
+        consumerBlobStorage1.triggerRefreshTo(version);
+
+        HollowPrimaryKeyIndex idxBlobStorage1 = new HollowPrimaryKeyIndex(consumerBlobStorage1.getStateEngine(), "TypeA", "id1", "id2");
+        Assert.assertFalse(idxBlobStorage1.containsDuplicates());
+
+        assertTypeA(idxBlobStorage1, 1, "one", 1L);
+        assertTypeA(idxBlobStorage1, 2, "two", 2L);
+        assertTypeA(idxBlobStorage1, 3, "three", 3L);
+        assertTypeA(idxBlobStorage1, 4, "four", 4L);
+        assertTypeA(idxBlobStorage1, 5, "five", 5L);
+
+        HollowConsumer consumerBlobStorage2 = HollowConsumer.withBlobRetriever(blobStorage2).build();
+        consumerBlobStorage2.triggerRefreshTo(version);
+
+        HollowPrimaryKeyIndex idxBlobStorage2 = new HollowPrimaryKeyIndex(consumerBlobStorage2.getStateEngine(), "TypeA", "id1", "id2");
+        Assert.assertFalse(idxBlobStorage2.containsDuplicates());
+
+        assertTypeA(idxBlobStorage2, 1, "one", 1L);
+        assertTypeA(idxBlobStorage2, 2, "two", 2L);
+        assertTypeA(idxBlobStorage2, 3, "three", 3L);
+        assertTypeA(idxBlobStorage2, 4, "four", 4L);
+        assertTypeA(idxBlobStorage2, 5, "five", 5L);
+    }
+
+    @SuppressWarnings("unused")
+    @HollowPrimaryKey(fields = {"id1", "id2"})
+    private static class TypeA {
+        int id1;
+        String id2;
+        long value;
+
+        public TypeA(int id1, String id2, long value) {
+            this.id1 = id1;
+            this.id2 = id2;
+            this.value = value;
+        }
+    }
+
+    private long initializeData(HollowProducer producer) {
+        return producer.runCycle(new Populator() {
+            public void populate(WriteState state) throws Exception {
+                state.add(new TypeA(1, "one", 1));
+                state.add(new TypeA(2, "two", 2));
+                state.add(new TypeA(3, "three", 3));
+                state.add(new TypeA(4, "four", 4));
+                state.add(new TypeA(5, "five", 5));
+            }
+        });
+    }
+
+    private void assertTypeA(HollowPrimaryKeyIndex typeAIdx, int id1,
+                             String id2, Long expectedValue) {
+        int ordinal = typeAIdx.getMatchingOrdinal(id1, id2);
+
+        if (expectedValue == null) {
+            Assert.assertEquals(-1, ordinal);
+        } else {
+            Assert.assertNotEquals(-1, ordinal);
+            GenericHollowObject obj = new GenericHollowObject(
+                    typeAIdx.getTypeState(), ordinal);
+            Assert.assertEquals(expectedValue.longValue(), obj.getLong("value"));
+        }
+    }
+
+    private HollowProducer createInMemoryProducer(AbstractHollowMultiPublisher multiPublisher) {
+        return HollowProducer.withPublisher(multiPublisher)
+                .withBlobStager(new HollowInMemoryBlobStager())
+                .build();
+    }
+
+}


### PR DESCRIPTION
Mirror of netflix hollow#213
Hi <at>toolbear <at>akhaku,

In our case, we publish the same snapshots/deltas on different providers/clouds (openstack, google cloud, s3) for consumption. 

This proposal is just to introduce `AbstractHollowMultiPublisher` as a type of `Publisher` that takes multiple `Publishers` and writes blob either in serial (`SingleHollowMultiPublisher`) or parallel fashion (`ParallelHollowMultiPublisher`). The idea is to provide users with similar use cases a base class they can use to push to different providers.

Sample usage:

```groovy
List<HollowProducer.Publisher> publishers = [myGCSPublisher, myS3Publisher, myOpenStackPublisher]

ParallelHollowMultiPublisher parallelHollowMultiPublisher = new ParallelHollowMultiPublisher(publishers, 1.0d)

HollowProducer.withPublisher(publishers).build()
```
thoughts?
