### PR TITLE
Mirror of netflix hollow#208

### DIFF
--- a/hollow/src/main/java/com/netflix/hollow/api/producer/HollowProducer.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/producer/HollowProducer.java
@@ -687,6 +687,7 @@ public class HollowProducer {
     		for(Validator validator: validators) {
     			Throwable throwable = null;
     			try {
+    			    validator.lock();
     				validator.validate(readState);
 	    		} catch (Throwable th) {
 	    			throwable = th;
@@ -917,6 +918,7 @@ public class HollowProducer {
     
     public static interface Validator {
         void validate(HollowProducer.ReadState readState);
+        void lock();
     
         @SuppressWarnings("serial")
         public static class ValidationException extends RuntimeException {

--- a/hollow/src/main/java/com/netflix/hollow/api/producer/validation/DuplicateDataDetectionValidator.java
+++ b/hollow/src/main/java/com/netflix/hollow/api/producer/validation/DuplicateDataDetectionValidator.java
@@ -89,6 +89,11 @@ public class DuplicateDataDetectionValidator implements Nameable, Validator {
 		handleEndValidation(statusBuilder, Status.SUCCESS, "");
 	}
 
+	@Override
+	public void lock() {
+		//Do nothing
+	}
+
 	private Collection<Object[]> getDuplicateKeys(HollowReadStateEngine stateEngine, PrimaryKey primaryKey) {
 		HollowTypeReadState typeState = stateEngine.getTypeState(dataTypeName);
 		HollowPrimaryKeyIndex hollowPrimaryKeyIndex = typeState.getListener(HollowPrimaryKeyIndex.class);

--- a/hollow/src/test/java/com/netflix/hollow/api/consumer/HollowProducerConsumerTests.java
+++ b/hollow/src/test/java/com/netflix/hollow/api/consumer/HollowProducerConsumerTests.java
@@ -255,6 +255,11 @@ public class HollowProducerConsumerTests {
                                                     @Override public void validate(ReadState readState) {
                                                         throw new ValidationException("Expected to fail!");
                                                     }
+
+                                                    @Override
+                                                    public void lock() {
+                                                        //do nothing
+                                                    }
                                                 })
                                                 .build();
         
@@ -276,6 +281,11 @@ public class HollowProducerConsumerTests {
                                                     @Override public void validate(ReadState readState) {
                                                         if(++counter == 2)
                                                             throw new ValidationException("Expected to fail!");
+                                                    }
+
+                                                    @Override
+                                                    public void lock() {
+                                                        //Do nothing
                                                     }
                                                 })
                                                 .build();


### PR DESCRIPTION
Mirror of netflix hollow#208
This is for https://github.com/Netflix/hollow/issues/204

Introduces a breaking change in the `Validator` by adding `lock` method.

The idea would be that users could do some changes to their validators on runtime and once a cycle gets into the validation state, this would happen:

```
validator.lock();
validator.validate(readState);
```

From the `RecordCountVarianceValidator`, `lock` assigns the `allowableVariancePercent` to `cycleAllowableVariancePercent` which is used for the validation. This way, `allowableVariancePercent` could change any time via `updateVariancePercent` without affecting the current cycle.

Other idea in order to prevent breaking changes:

* Introduce a `ValidatorV2` interface (same way it happened with the `Listeners`) which would contain `validate(readState)` and `lock`. 
* Introduce a `DynamicRecordCountVarianceValidator` that uses `ValidatorV2` and has the functionality in https://github.com/Netflix/hollow/issues/204.

I'm also asking myself if `lock` is a good name or perhaps use something like `prepareForReadStateValidation` to keep the semantics

Thoughts <at>toolbear <at>akhaku ?
