### PR TITLE
Mirror of netflix hollow#245

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,6 +13,11 @@ subprojects {
   sourceCompatibility = 1.8
   targetCompatibility = 1.8
 
+  tasks.withType(JavaCompile) {
+    sourceCompatibility = 1.8
+    targetCompatibility = 1.8
+  }
+
   group = 'com.netflix.hollow'
   checkstyle {
     configFile = file("$rootProject.projectDir/config/checkstyle/checkstyle.xml")

--- a/hollow-test/src/main/java/com/netflix/hollow/test/model/TestTypeA.java
+++ b/hollow-test/src/main/java/com/netflix/hollow/test/model/TestTypeA.java
@@ -1,0 +1,11 @@
+package com.netflix.hollow.test.model;
+
+public class TestTypeA {
+    int id;
+    String name;
+
+    public TestTypeA(int id, String name) {
+        this.id = id;
+        this.name = name;
+    }
+}

--- a/hollow/build.gradle
+++ b/hollow/build.gradle
@@ -1,6 +1,7 @@
 apply plugin: 'java'
  
 dependencies {
+    testCompile project(":hollow-test")
     testCompile 'junit:junit:4.11'
     testCompile 'org.mockito:mockito-core:2.15.0'
     testCompile 'com.google.code.findbugs:findbugs:3.0.1'

--- a/hollow/src/main/java/com/netflix/hollow/tools/stringifier/HollowRecordJsonStringifier.java
+++ b/hollow/src/main/java/com/netflix/hollow/tools/stringifier/HollowRecordJsonStringifier.java
@@ -37,6 +37,7 @@ import java.io.Writer;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.Set;
 
 /**
@@ -85,6 +86,19 @@ public class HollowRecordJsonStringifier implements HollowStringifier<HollowReco
     @Override
     public void stringify(Writer writer, HollowRecord record) throws IOException {
         stringify(writer, record.getTypeDataAccess().getDataAccess(), record.getSchema().getName(), record.getOrdinal());
+    }
+
+    @Override
+    public void stringify(Writer writer, Iterable<HollowRecord> records) throws IOException {
+        writer.write("[");
+        Iterator<HollowRecord> iterator = records.iterator();
+        while (iterator.hasNext()) {
+            stringify(writer, iterator.next());
+            if (iterator.hasNext()) {
+                writer.write(",");
+            }
+        }
+        writer.write("]");
     }
 
     @Override

--- a/hollow/src/main/java/com/netflix/hollow/tools/stringifier/HollowRecordStringifier.java
+++ b/hollow/src/main/java/com/netflix/hollow/tools/stringifier/HollowRecordStringifier.java
@@ -38,6 +38,7 @@ import java.io.StringWriter;
 import java.io.Writer;
 import java.util.Arrays;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.Set;
 
 /**
@@ -78,6 +79,19 @@ public class HollowRecordStringifier implements HollowStringifier<HollowRecordSt
     public void stringify(Writer writer, HollowRecord record) throws IOException {
         stringify(writer, record.getTypeDataAccess().getDataAccess(), record.getSchema().getName(),
                 record.getOrdinal());
+    }
+
+    @Override
+    public void stringify(Writer writer, Iterable<HollowRecord> records) throws IOException {
+        writer.write("[");
+        Iterator<HollowRecord> iterator = records.iterator();
+        while (iterator.hasNext()) {
+            stringify(writer, iterator.next());
+            if (iterator.hasNext()) {
+                writer.write(",");
+            }
+        }
+        writer.write("\n]");
     }
 
     @Override

--- a/hollow/src/main/java/com/netflix/hollow/tools/stringifier/HollowStringifier.java
+++ b/hollow/src/main/java/com/netflix/hollow/tools/stringifier/HollowStringifier.java
@@ -49,7 +49,9 @@ public interface HollowStringifier<T extends HollowStringifier> {
      *
      * @throws IOException thrown if there is an error writing to the Writer
      */
-    public void stringify(Writer writer,Iterable<HollowRecord> records) throws IOException;
+    public default void stringify(Writer writer,Iterable<HollowRecord> records) throws IOException {
+        //Do nothing
+    }
 
     /**
      * Create a String representation of the record in the provided dataset, of the given type, with the specified ordinal.

--- a/hollow/src/main/java/com/netflix/hollow/tools/stringifier/HollowStringifier.java
+++ b/hollow/src/main/java/com/netflix/hollow/tools/stringifier/HollowStringifier.java
@@ -45,6 +45,13 @@ public interface HollowStringifier<T extends HollowStringifier> {
     public void stringify(Writer writer, HollowRecord record) throws IOException;
 
     /**
+     * Writes a String representation of the specified collection of {@link HollowRecord} to the provided Writer.
+     *
+     * @throws IOException thrown if there is an error writing to the Writer
+     */
+    public void stringify(Writer writer,Iterable<HollowRecord> records) throws IOException;
+
+    /**
      * Create a String representation of the record in the provided dataset, of the given type, with the specified ordinal.
      */
     public String stringify(HollowDataAccess dataAccess, String type, int ordinal);

--- a/hollow/src/test/java/com/netflix/hollow/tools/stringifier/HollowRecordJsonStringifierTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/tools/stringifier/HollowRecordJsonStringifierTest.java
@@ -20,9 +20,6 @@ package com.netflix.hollow.tools.stringifier;
 import static com.netflix.hollow.tools.stringifier.HollowStringifier.INDENT;
 import static com.netflix.hollow.tools.stringifier.HollowStringifier.NEWLINE;
 
-import java.io.IOException;
-import java.io.StringWriter;
-import java.util.Arrays;
 
 import com.netflix.hollow.api.objects.HollowRecord;
 import com.netflix.hollow.api.objects.generic.GenericHollowObject;
@@ -31,6 +28,9 @@ import com.netflix.hollow.core.util.StateEngineRoundTripper;
 import com.netflix.hollow.core.write.HollowWriteStateEngine;
 import com.netflix.hollow.core.write.objectmapper.HollowObjectMapper;
 import com.netflix.hollow.test.model.TestTypeA;
+import java.io.IOException;
+import java.io.StringWriter;
+import java.util.Arrays;
 import org.junit.Assert;
 import org.junit.Test;
 

--- a/hollow/src/test/java/com/netflix/hollow/tools/stringifier/HollowRecordJsonStringifierTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/tools/stringifier/HollowRecordJsonStringifierTest.java
@@ -21,6 +21,16 @@ import static com.netflix.hollow.tools.stringifier.HollowStringifier.INDENT;
 import static com.netflix.hollow.tools.stringifier.HollowStringifier.NEWLINE;
 
 import java.io.IOException;
+import java.io.StringWriter;
+import java.util.Arrays;
+
+import com.netflix.hollow.api.objects.HollowRecord;
+import com.netflix.hollow.api.objects.generic.GenericHollowObject;
+import com.netflix.hollow.core.read.engine.HollowReadStateEngine;
+import com.netflix.hollow.core.util.StateEngineRoundTripper;
+import com.netflix.hollow.core.write.HollowWriteStateEngine;
+import com.netflix.hollow.core.write.objectmapper.HollowObjectMapper;
+import com.netflix.hollow.test.model.TestTypeA;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -114,9 +124,30 @@ public class HollowRecordJsonStringifierTest extends AbstractHollowRecordStringi
                     new TypeWithString("foo"), new TypeWithString("bar")));
     }
 
+    @Test
+    public void testStringifyIterator() throws IOException {
+        HollowRecordJsonStringifier recordJsonStringifier = new HollowRecordJsonStringifier(false, false);
+        HollowWriteStateEngine writeEngine = new HollowWriteStateEngine();
+        HollowObjectMapper mapper = new HollowObjectMapper(writeEngine);
+        mapper.useDefaultHashKeys();
+
+        mapper.add(new TestTypeA(1, "one"));
+        mapper.add(new TestTypeA(2, "two"));
+
+        HollowReadStateEngine readEngine = StateEngineRoundTripper.roundTripSnapshot(writeEngine);
+
+        Iterable<HollowRecord> genericHollowObjects = (Iterable) Arrays.asList(new GenericHollowObject(readEngine, "TestTypeA", 0), new GenericHollowObject(readEngine, "TestTypeA", 1));
+
+        StringWriter writer = new StringWriter();
+        recordJsonStringifier.stringify(writer, genericHollowObjects);
+        Assert.assertEquals("Multiple records should be printed correctly",
+                "[{\"id\": 1,\"name\": {\"value\": \"one\"}},{\"id\": 2,\"name\": {\"value\": \"two\"}}]", writer.toString());
+    }
+
     private static <T> String stringifyType(Class<T> clazz, boolean expanded, T... instances) throws IOException {
         HollowRecordJsonStringifier stringifier = expanded
             ? new HollowRecordJsonStringifier(true, false) : new HollowRecordJsonStringifier();
         return stringifyType(clazz, stringifier, instances);
     }
+
 }

--- a/hollow/src/test/java/com/netflix/hollow/tools/stringifier/HollowRecordStringifierTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/tools/stringifier/HollowRecordStringifierTest.java
@@ -20,10 +20,6 @@ package com.netflix.hollow.tools.stringifier;
 import static com.netflix.hollow.tools.stringifier.HollowStringifier.INDENT;
 import static com.netflix.hollow.tools.stringifier.HollowStringifier.NEWLINE;
 
-import java.io.IOException;
-import java.io.StringWriter;
-import java.util.Arrays;
-
 import com.netflix.hollow.api.objects.HollowRecord;
 import com.netflix.hollow.api.objects.generic.GenericHollowObject;
 import com.netflix.hollow.core.read.engine.HollowReadStateEngine;
@@ -31,6 +27,9 @@ import com.netflix.hollow.core.util.StateEngineRoundTripper;
 import com.netflix.hollow.core.write.HollowWriteStateEngine;
 import com.netflix.hollow.core.write.objectmapper.HollowObjectMapper;
 import com.netflix.hollow.test.model.TestTypeA;
+import java.io.IOException;
+import java.io.StringWriter;
+import java.util.Arrays;
 import org.junit.Assert;
 import org.junit.Test;
 


### PR DESCRIPTION
Mirror of netflix hollow#245
Hi <at>toolbear,

We have a use case where we search for `HollowObjects` using a `HashIndex`, for example `BookAPIHashIndex` where the model is:

```Book.java
<at>HollowPrimaryKey(fields={"bookId"})
public class Book {
    long bookId;
    String title;
    String publisher;
}
```

The `HashIndex` returns a `Iterable<Book>` and we wanted to Stringify this right away as a JSON to serve it via HTTP server.

The current implementation for `HollowStringifier.java` doesn't support a method that takes a `Writer` and `Iterable<HollowObject>` as arguments and stringify them properly.

This change includes a default method which does nothing for `HollowStringifier` in case Hollow users are implementing their own stringifiers and also default implementation for `HollowRecordJsonStringifier` and `HollowRecordStringifier`

Please let me know your thoughts or if you think there is a better way to accomplish this

I'm also proposing adding re-usable test types (POJOs) to `hollow-test` project so they could be shared across multiple tests and potentially simplify some tests. Please look at `TestTypeA` and let me know what you think of this approach
