### PR TITLE
Mirror of netflix hollow#234

### DIFF
--- a/hollow/src/main/java/com/netflix/hollow/tools/stringifier/HollowRecordJsonStringifier.java
+++ b/hollow/src/main/java/com/netflix/hollow/tools/stringifier/HollowRecordJsonStringifier.java
@@ -36,7 +36,9 @@ import java.io.StringWriter;
 import java.io.Writer;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
 
 /**
@@ -48,6 +50,18 @@ public class HollowRecordJsonStringifier implements HollowStringifier<HollowReco
     private final Set<String> excludeObjectTypes = new HashSet<String>();
     private final boolean collapseAllSingleFieldObjects;
     private final boolean prettyPrint;
+
+    private Map<Character, String> escapedSymbols = Collections.unmodifiableMap(
+            new HashMap<Character, String>() {
+                {
+                    put('\t', "\\\\t");
+                    put('\b', "\\\\b");
+                    put('\f', "\\\\f");
+                    put('\n', "\\\\n");
+                    put('\r', "\\\\r");
+                    put('\"', "\\\"");
+                }
+            });
 
     public HollowRecordJsonStringifier() {
         this(true, true);
@@ -384,9 +398,12 @@ public class HollowRecordJsonStringifier implements HollowStringifier<HollowReco
     }
 
     private String escapeString(String str) {
-        if(str.indexOf('\\') == -1 && str.indexOf('\"') == -1)
-            return str;
-        return str.replace("\\", "\\\\").replace("\"", "\\\"");
+        for (Character escapeSequence : escapedSymbols.keySet()) {
+            if (str.indexOf(escapeSequence) > -1) {
+                str = str.replace(escapeSequence.toString(), escapedSymbols.get(escapeSequence));
+            }
+        }
+        return str;
     }
 
     private void appendIndentation(Writer writer, int indentation) throws IOException {

--- a/hollow/src/test/java/com/netflix/hollow/tools/stringifier/HollowRecordJsonStringifierTest.java
+++ b/hollow/src/test/java/com/netflix/hollow/tools/stringifier/HollowRecordJsonStringifierTest.java
@@ -39,6 +39,19 @@ public class HollowRecordJsonStringifierTest extends AbstractHollowRecordStringi
     }
 
     @Test
+    public void testStringifyTypeWithSpecialCharactersInString() throws IOException {
+        String msg = "String types should be printed correctly";
+        Assert.assertEquals(msg, "\"foo " + "\\\\t" + " " + "\\\"foo" + "\\\" " + "\\\\r" + " foo " + "\\\\n\"",
+                stringifyType(TypeWithString.class, false, new TypeWithString("foo \t \"foo\" \r foo \n")));
+        Assert.assertEquals(msg, "{" + NEWLINE
+                        + INDENT + "\"value\": {" + NEWLINE
+                        + INDENT + INDENT + "\"value\": \"foo " + "\\\\t" + " " + "\\\"foo" + "\\\" " + "\\\\r" + " foo " + "\\\\n\"" + NEWLINE
+                        + INDENT + "}" + NEWLINE
+                        + "}",
+                stringifyType(TypeWithString.class, true, new TypeWithString("foo \t \"foo\" \r foo \n")));
+    }
+
+    @Test
     public void testStringifyTypeWithPrimitive() throws IOException {
         String msg = "Primitive types should be printed correctly";
         Assert.assertEquals(msg, "1337",


### PR DESCRIPTION
Mirror of netflix hollow#234
Special characters like \t, \b, etc were not escaped during creating JSON from records and this case was not covered with tests. Fixed escaping and added junit.
